### PR TITLE
Disable bot automerge and add lower bound on r-rcpp

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,5 @@
 bot:
-  automerge: true
+  automerge: false
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 09e1d3943c2c908732a6f459b1a0af6381969d23ab841168d21198d4f29991af
 
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/
@@ -30,21 +30,21 @@ requirements:
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
     - cross-r-base {{ r_base }}    # [build_platform != target_platform]
-    - r-rcpp                       # [build_platform != target_platform]
+    - r-rcpp >=1.1.1               # [build_platform != target_platform]
     - r-rcppcctz >=0.2.9           # [build_platform != target_platform]
     - r-rcppdate                   # [build_platform != target_platform]
     - r-bit64                      # [build_platform != target_platform]
     - r-zoo                        # [build_platform != target_platform]
   host:
     - r-base
-    - r-rcpp
+    - r-rcpp >=1.1.1
     - r-rcppcctz >=0.2.9
     - r-rcppdate
     - r-bit64
     - r-zoo
   run:
     - r-base
-    - r-rcpp
+    - r-rcpp >=1.1.1
     - r-rcppcctz >=0.2.9
     - r-rcppdate
     - r-bit64


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

---

Follow-up to #26. I don't like that the bot automerge's before I can review the changes. In this case, it missed the introduction of a lower bound of 1.1.1 on Rcpp

https://github.com/eddelbuettel/nanotime/compare/a86006d187d719ec72a2117e3e1481f93f823b10...e2486c401cc9ee2f75d36fdf7a36465e212b3998 